### PR TITLE
Applied reworked version of PR1268 by wbahnassi-if

### DIFF
--- a/src/input/UnicodeKeymap.cc
+++ b/src/input/UnicodeKeymap.cc
@@ -75,12 +75,12 @@ static void skipSep(string_view& str)
 static string_view nextToken(string_view& str)
 {
 	skipSep(str);
-	auto tokenBegin = str.begin();
+	auto tokenBegin = str.data();
 	while (!str.empty() && str.front() != '\n' && !isSep(str.front())) {
 		// Pop non-separator character.
 		str.remove_prefix(1);
 	}
-	return string_view(&*tokenBegin, str.begin() - tokenBegin);
+	return string_view(tokenBegin, str.data() - tokenBegin);
 }
 
 


### PR DESCRIPTION
See:
  https://github.com/openMSX/openMSX/pull/1268/files

I have to admit I don't fully understand the reason for the PR. But it seems
like a workaround for a too strict check in the visual studio debug STL
version?

In this reworked version I fixed it by using 'char*' instead of
string_view::iterator. But I have not tested this on msvc, so I don't know if
this actually fixes the original problem.